### PR TITLE
♻️ Used `BlockTag.latest` instead of refetching for the new block every 3 seconds

### DIFF
--- a/src/app/trade/_components/footer-block-number.tsx
+++ b/src/app/trade/_components/footer-block-number.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useBlock, useNetwork } from "@starknet-react/core";
+import { BlockTag } from "starknet";
 
 const testnetBlockUrl = "https://goerli.voyager.online/block";
 
 export default function FooterBlockNumber() {
-  const { data: block } = useBlock({ refetchInterval: 3000 });
+  const { data: block } = useBlock({ blockIdentifier: BlockTag.latest });
 
   const { chain } = useNetwork();
 


### PR DESCRIPTION
<!-- IMPORTANT
📣 Use Gitmoji in the pull request name to give a quick overview of the change (https://gitmoji.dev/). Examples:
- ✨ for a new feature
- 🐛 for a bug fix
- 📝 for documentation changes
- ♻️ for code refactoring/cleanup
- 🎨 for UI/UX improvements
- ⬆️ for dependency updates -->

## Related Issues
<!-- 🐛 Link to any related issues or tasks (e.g., issue #123). -->
#65

## Checklist
- [x] ✅ All existing tests pass.
- [x] 📃 Documentation has been updated (if necessary).
- [x] 🚀 This PR has been tested locally and is ready for review.
